### PR TITLE
ares: gb: fix cgb hdma abort bug

### DIFF
--- a/ares/gb/cpu/io.cpp
+++ b/ares/gb/cpu/io.cpp
@@ -240,11 +240,12 @@ auto CPU::writeIO(uint cycle, uint16 address, uint8 data) -> void {
 
   if(Model::GameBoyColor())
   if(address == 0xff55 && cycle == 2) {  //HDMA5
+    const auto dmaWasCompleted = status.dmaCompleted;
     status.dmaLength    = (data.bit(0,6) + 1) * 16;
     status.dmaMode      = data.bit(7);
     status.dmaCompleted = !status.dmaMode;
 
-    if(status.dmaMode == 0) {
+    if(dmaWasCompleted && status.dmaMode == 0) {
       do {
         for(uint loop : range(16)) {
           writeDMA(status.dmaTarget++, readDMA(status.dmaSource++, 0xff));

--- a/ares/gb/cpu/timing.cpp
+++ b/ares/gb/cpu/timing.cpp
@@ -83,11 +83,13 @@ auto CPU::hblank() -> void {
 }
 
 auto CPU::hblankTrigger() -> void {
-  if(status.dmaMode == 1 && status.dmaLength && ppu.status.ly < 144) {
+  if(status.dmaMode == 1 && !status.dmaCompleted && status.dmaLength && ppu.status.ly < 144) {
     for(uint n : range(16)) {
       writeDMA(status.dmaTarget++, readDMA(status.dmaSource++, 0xff));
       status.dmaLength--;
       if(n & 1) step(1 << status.speedDouble);
     }
+  if (0 == status.dmaLength)
+    status.dmaCompleted = 1;
   }
 }


### PR DESCRIPTION
Back in the old days, I reported an issue with the GBC emulation that resulted in graphics corruption on Pokemon Crystal. A developer using the name Tauwasser provided a patch in the old forums. Unfortunately, this patch never made it to higan.

I managed to salvage this patch from the net and applied it to the latest ares codebase - it still works!

Before:
![ares-gb-bug](https://user-images.githubusercontent.com/11882577/90328006-35926b80-df99-11ea-9a0d-4a135eb979cf.PNG)

After:
![ares-gb-bug-resolved](https://user-images.githubusercontent.com/11882577/90327950-b866f680-df98-11ea-9782-e0f75a47b9b0.PNG)

However, there are unfortunately still some issues with the GBC emulation, like the clock for MBC3 games not working properly and this palette bug:
![ares-gbc-palette-issue](https://user-images.githubusercontent.com/11882577/90327975-e9472b80-df98-11ea-8518-011c040fb20f.PNG)
It looks like the colors for the sprites are not loaded properly unless the entire screen/palette is swapped once. I can't remember to have seen this issue back in the v106 days though.
